### PR TITLE
Allow showing all pages with -1 as page number

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,15 @@
 # Gofork
+
 ## Presentation
+
 Gofork is a CLI tool to find forks that are ahead of a github repository.
+
 ## Usage
-```
+
+```shell
 $ gofork --help
-usage: gofork [-h|--help] -r|--repo "<value>" [-b|--branch "<value>"]
-              [-p|--private]
+usage: gofork [-h|--help] [-r|--repo "<value>"] [-b|--branch "<value>"]
+              [-v|--verbose] [-p|--page <integer>]
 
               CLI tool to find active forks
 
@@ -14,17 +18,23 @@ Arguments:
   -h  --help     Print help information
   -r  --repo     Repository to check
   -b  --branch   Branch to check. Default: repo default branch
-  -p  --private  Show private repositories
+  -v  --verbose  Show private and up to date repositories
+  -p  --page     Page to check (use -1 for all). Default: 1
 ```
+
 ## Roadmap
+
 * [x] Print the results in table
 * [x] Add support for branches (with the default being the repo default branch)
 * [x] Use terminal colors
 * [x] Verbose flag for private/even forks
 * [x] Loading bar
 * [X] Sort output
+
 ## Built with
+
 Built with love using [Golang](https://golang.org), [Github API](https://developer.github.com/v3/) and [akamensky's argparse](github.com/akamensky/argparse), [gookit's color](github.com/gookit/color), [olekukonko's tablewriter](github.com/olekukonko/tablewriter), [schollz's progressbar](github.com/schollz/progressbar/v3) libraries.
 
 ## License
+
 [![License: GPL v3](https://img.shields.io/badge/License-GPLv3-blue.svg)](https://www.gnu.org/licenses/gpl-3.0)

--- a/gofork.go
+++ b/gofork.go
@@ -142,15 +142,6 @@ func main() {
 				color.Warn.Println(warning + " The page is out of range (max. " + strconv.Itoa(pages) + "), showing page 1")
 				*page = 1
 			}
-			// This is separate from the above if because of it crashes if there is less than 100 forks
-			if *page < 1 {
-				if *page != -1 {
-					color.Warn.Println(warning + " The number of page is lower than 1, showing page 1")
-					pages = 1
-					RepoInfo.ForkCount = 100
-				}
-				*page = 1
-			}
 			if RepoInfo.ForkCount > 100 && *page == 1 {
 				RepoInfo.ForkCount = 100
 				// Force the loop to iterate over the selected page only
@@ -165,6 +156,14 @@ func main() {
 			}
 			if RepoInfo.ForkCount > 100 && *page == -1 {
 				color.Info.Println(mitigate + " More than 100 forks found, showing page all pages because -p is used with -1")
+			}
+			if *page < 1 {
+				if *page != -1 {
+					color.Warn.Println(warning + " The number of page is lower than 1, showing page 1")
+					pages = 1
+					RepoInfo.ForkCount = 100
+				}
+				*page = 1
 			}
 			ahead := list.New()
 			behind := list.New()


### PR DESCRIPTION
This pull request allows selecting -1 as page to show all forks. It also adds a warning when the page number is too big or too low.